### PR TITLE
Use PACKAGE arg in .C() calls

### DIFF
--- a/R/primefactors.R
+++ b/R/primefactors.R
@@ -135,7 +135,8 @@ primefactors <- function(n, method=c("C", "interpreted")) {
            z <- .C("primefax",
                    n=as.integer(n),
                    factors=as.integer(integer(kmax)),
-                   nfactors=as.integer(integer(1L)))
+                   nfactors=as.integer(integer(1L)),
+                   PACKAGE = "spatstat.utils")
            result <- z$factors[seq_len(z$nfactors)]
          },
          stop("Unrecognised method"))

--- a/R/tapplysum.R
+++ b/R/tapplysum.R
@@ -61,7 +61,8 @@ tapplysum <- function(x, flist, do.names=FALSE, na.rm=TRUE) {
                nout = as.integer(integer(1L)),
                xout = as.double(numeric(n)),
                iout = as.integer(integer(n)),
-               jout = as.integer(integer(n)))
+               jout = as.integer(integer(n)),
+               PACKAGE = "spatstat.utils")
       nout <- zz$nout
       if(nout > 0) {
         ijout <- cbind(zz$iout, zz$jout)[1:nout,,drop=FALSE]
@@ -83,7 +84,8 @@ tapplysum <- function(x, flist, do.names=FALSE, na.rm=TRUE) {
                xout = as.double(numeric(n)),
                iout = as.integer(integer(n)),
                jout = as.integer(integer(n)),
-               kout = as.integer(integer(n)))
+               kout = as.integer(integer(n)),
+               PACKAGE = "spatstat.utils")
       nout <- zz$nout
       if(nout > 0) {
         ijkout <- cbind(zz$iout, zz$jout, zz$kout)[1:nout,,drop=FALSE]

--- a/R/utilseq.R
+++ b/R/utilseq.R
@@ -37,12 +37,14 @@ revcumsum <- function(x) {
   if(identical(storage.mode(x), "integer")) {
     z <- .C("irevcumsum",
             x=as.integer(x),
-            as.integer(n))
+            as.integer(n),
+            PACKAGE = "spatstat.utils")
     return(z$x)
   } else {
     z <- .C("drevcumsum",
             x=as.double(x),
-            as.integer(n))
+            as.integer(n),
+            PACKAGE = "spatstat.utils")
     return(z$x)
   }
 }
@@ -269,7 +271,8 @@ fastFindInterval <- function(x, b, labels=FALSE, reltol=0.001) {
              n          = as.integer(nx),
              brange     = as.double(range(b)),
              nintervals = as.integer(nintervals),
-             y          = as.integer(integer(nx))
+             y          = as.integer(integer(nx)),
+             PACKAGE = "spatstat.utils"
              )
     y <- zz$y
   } else {

--- a/R/xypolygon.R
+++ b/R/xypolygon.R
@@ -47,7 +47,8 @@ inside.xypolygon <- function(pts, polly, test01=TRUE, method="C") {
           nb=as.integer(nedges),
           xb=as.double(xp),
           yb=as.double(yp),
-          match=as.integer(integer(npts)))
+          match=as.integer(integer(npts)),
+          PACKAGE = "spatstat.utils")
   is.vertex <- (z$match != 0)
   retain <- !is.vertex
   # Remove vertices from subsequent consideration; replace them later
@@ -73,7 +74,8 @@ inside.xypolygon <- function(pts, polly, test01=TRUE, method="C") {
                         npts=as.integer(npts),
                         nedges=as.integer(nedges),
                         score=as.integer(score),
-                        onbndry=as.integer(on.boundary))
+                        onbndry=as.integer(on.boundary),
+                        PACKAGE = "spatstat.utils")
              score <- temp$score/2
              on.boundary <- as.logical(temp$onbndry)
            },

--- a/R/xysegment.R
+++ b/R/xysegment.R
@@ -175,7 +175,8 @@ distppll <- function(p, l, mintype=0,
                       y1=as.double(l[,4]),
                       nsegments=as.integer(nl),
                       epsilon=as.double(eps),
-                      dist2=as.double(numeric(np * nl)))
+                      dist2=as.double(numeric(np * nl)),
+                      PACKAGE = "spatstat.utils")
            d <- matrix(sqrt(temp$dist2), nrow=np, ncol=nl)
            if(mintype == 2) {
              min.which <- apply(d, 1, which.min)
@@ -224,7 +225,8 @@ NNdist2segments <- function(xp, yp, x0, y0, x1, y1, bigvalue) {
           nsegments=as.integer(ns),
           epsilon=as.double(.Machine$double.eps),
           dist2=as.double(dist2),
-          index=as.integer(integer(np)))
+          index=as.integer(integer(np)),
+          PACKAGE = "spatstat.utils")
   return(list(dist2=z$dist2,
               index=z$index + 1L))
 }


### PR DESCRIPTION
The `spatstat` package is going to feature prominently in an upcoming DataCamp course. Unfortunately, neither the version on CRAN, nor the development version work correctly on the DataCamp platform.  The problem is that when C code is called, sometimes an error occurs regarding locating the call.

```r
ppp(x=runif(10), y=runif(10), window=disc(radius=10))
## Error: "Cmatchxy" not resolved from current namespace (spatstat)
```

The fix is to include a `PACKAGE` argument to calls to `.C()` and `.Call()`. This fix should be applicable to other platforms too, making `spatstat` more widely available.

I've also made this change to the dependencies `spatstat.utils` and `polyclip`.