### PR TITLE
Fix as2vector list-coordinate length validation

### DIFF
--- a/R/utilseq.R
+++ b/R/utilseq.R
@@ -73,7 +73,7 @@ as2vector <- function(x) {
     stop(paste(xname, "should consist of exactly one point"))
   }
   if(is.list(x) && all(c("x", "y") %in% names(x))) {
-    if(length(x$x) == 1 && length(x$y == 1))
+    if(length(x$x) == 1 && length(x$y) == 1)
       return(c(x$x, x$y))
     xname <- short.deparse(substitute(x))
     if(length(x$x) != 1) stop(paste0(xname, "$x should have length 1"))

--- a/tests/numerical.R
+++ b/tests/numerical.R
@@ -90,6 +90,9 @@ revcumsum(1:5 * (1 + 2i))
 
 as2vector(3:4)
 as2vector(list(x=1, y=1))
+#' regression test for list-coordinate length validation (utilseq.R)
+stopifnot(identical(as2vector(list(x=1, y=1)), c(1, 1)))
+stopifnot(inherits(try(as2vector(list(x=1, y=1:2)), silent=TRUE), "try-error"))
 ensure2vector(3:4)
 ensure2vector(3)
 


### PR DESCRIPTION
as2vector() validates list coordinates before converting them to a length-two numeric vector. The y-component check read `length(x$y == 1)`, which measures the comparison result and is true for any non-empty y component. A list such as `list(x = 1, y = 1:2)` therefore returned a three-element vector instead of the intended validation error.

Check `length(x$y) == 1` so malformed list coordinates reach the existing error path.

Add regression coverage for a valid list point and a multi-element y component.

Found during my https://github.com/sims1253/ry audit